### PR TITLE
don't be strict with url scheme

### DIFF
--- a/websocket/__init__.py
+++ b/websocket/__init__.py
@@ -174,10 +174,10 @@ def _parse_url(url):
         port = parsed.port
 
     is_secure = False
-    if scheme == "ws":
+    if scheme == "ws" or scheme = "http":
         if not port:
             port = 80
-    elif scheme == "wss":
+    elif scheme == "wss" or scheme == "https":
         is_secure = True
         if not port:
             port = 443


### PR DESCRIPTION
I had some trouble connecting to a webservice that was only exposed via http/https scheme (server was in local network, exposed with ngrok and ngrok does not understand scheme ws/wss).

Accept http/https as schemes and treat them the same as ws and wss.