### PR TITLE
ssl_match_hostname code was added in 2.7.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,10 @@ VERSION = "0.24.0"
 NAME="websocket-client"
 
 install_requires = ["six"]
-if sys.version_info[0] == 2:
-    install_requires.append('backports.ssl_match_hostname')
-    if sys.version_info[1] < 7:
+if sys.version_info.major == 2:
+    if sys.version_info.minor == 7 and sys.version_info.micro < 9:
+        install_requires.append('backports.ssl_match_hostname')
+    if sys.version_info.minor < 7:
         install_requires.append('unittest2')
         install_requires.append('argparse')
 


### PR DESCRIPTION
The code from `backports.ssl_match_hostname` has been merged into the standard library in Python 2.7.9.

https://www.python.org/downloads/release/python-279/
> The entirety of Python 3.4's ssl module has been backported for Python 2.7.9. See PEP 466 for justification.