### PR TITLE
Fixed errno NameError

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -48,7 +48,6 @@ else:
     from base64 import encodestring as base64encode
 
 import os
-import errno
 import struct
 import threading
 

--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -22,6 +22,7 @@ Copyright (C) 2010 Hiroki Ohtani(liris)
 
 import six
 import socket
+import errno
 
 try:
     import ssl


### PR DESCRIPTION
Moved the import errno statement from `_core.py` to `_http.py` to fix a `NameError` on line 108 of `_http.py`.