### PR TITLE
Fix exception in recv() when ssl module is not available

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -25,23 +25,6 @@ from __future__ import print_function
 import six
 import socket
 
-try:
-    import ssl
-    from ssl import SSLError
-    if hasattr(ssl, "match_hostname"):
-        from ssl import match_hostname
-    else:
-        from backports.ssl_match_hostname import match_hostname
-
-    HAVE_SSL = True
-except ImportError:
-    # dummy class of SSLError for ssl none-support environment.
-    class SSLError(Exception):
-        pass
-
-    HAVE_SSL = False
-
-
 if six.PY3:
     from base64 import encodebytes as base64encode
 else:
@@ -60,6 +43,7 @@ from ._url import *
 from ._logging import *
 from ._http import *
 from ._handshake import *
+from ._ssl_compat import *
 
 """
 websocket python client.

--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -24,22 +24,6 @@ import six
 import socket
 import errno
 
-try:
-    import ssl
-    from ssl import SSLError
-    if hasattr(ssl, "match_hostname"):
-        from ssl import match_hostname
-    else:
-        from backports.ssl_match_hostname import match_hostname
-
-    HAVE_SSL = True
-except ImportError:
-    # dummy class of SSLError for ssl none-support environment.
-    class SSLError(Exception):
-        pass
-
-    HAVE_SSL = False
-
 if six.PY3:
     from base64 import encodebytes as base64encode
 else:
@@ -49,6 +33,7 @@ from ._logging import *
 from ._url import *
 from ._socket import*
 from ._exceptions import *
+from ._ssl_compat import *
 
 __all__ = ["proxy_info", "connect", "read_headers"]
 

--- a/websocket/_socket.py
+++ b/websocket/_socket.py
@@ -25,6 +25,7 @@ import six
 
 from ._exceptions import *
 from ._utils import *
+from ._ssl_compat import *
 
 DEFAULT_SOCKET_OPTION = [(socket.SOL_TCP, socket.TCP_NODELAY, 1)]
 if hasattr(socket, "SO_KEEPALIVE"):

--- a/websocket/_ssl_compat.py
+++ b/websocket/_ssl_compat.py
@@ -1,0 +1,41 @@
+"""
+websocket - WebSocket client library for Python
+
+Copyright (C) 2010 Hiroki Ohtani(liris)
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1335  USA
+
+"""
+
+__all__ = ["HAVE_SSL"]
+
+try:
+    import ssl
+    from ssl import SSLError
+    if hasattr(ssl, "match_hostname"):
+        from ssl import match_hostname
+    else:
+        from backports.ssl_match_hostname import match_hostname
+    __all__.append("match_hostname")
+
+    HAVE_SSL = True
+except ImportError:
+    # dummy class of SSLError for ssl none-support environment.
+    class SSLError(Exception):
+        pass
+
+    __all__.append("SSLError")
+    HAVE_SSL = False


### PR DESCRIPTION
This extracts a common code of conditionally importing ssl into a separate file and imports it from _socket.py (in addition to two places this code used to be), so that a reference to SSLError in _socket.py does not cases error.