### PR TITLE
Add new argument "host_only" in the options.

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -67,7 +67,7 @@ def _get_handshake_headers(resource, host, port, options):
     headers.append("GET %s HTTP/1.1" % resource)
     headers.append("Upgrade: websocket")
     headers.append("Connection: Upgrade")
-    if port == 80:
+    if port == 80 or ("host_only" in options and options["host_only"] == True):
         hostport = host
     else:
         hostport = "%s:%d" % (host, port)


### PR DESCRIPTION
Currently, all "wss" or "https" protocol will add "443" at the end of the "Host" field. But for some reverse_proxy server, the server settings does not allow 443 port, but delegate the original host to a certain internal port. So it would better to provide a way to disable the default behavior.
Default value: host_only=False

How to use it?
In the ws.connect method:
ws.connect("wss://demo.net/",  cookie=CookieString, origin=Origin, host_only=True)