### PR TITLE
Fix #175: Use builtin check_hostname when available

### DIFF
--- a/websocket/_ssl_compat.py
+++ b/websocket/_ssl_compat.py
@@ -25,11 +25,16 @@ __all__ = ["HAVE_SSL", "ssl", "SSLError"]
 try:
     import ssl
     from ssl import SSLError
-    if hasattr(ssl, "match_hostname"):
-        from ssl import match_hostname
+    if hasattr(ssl, 'SSLContext') and hasattr(ssl.SSLContext, 'check_hostname'):
+        HAVE_CONTEXT_CHECK_HOSTNAME = True
     else:
-        from backports.ssl_match_hostname import match_hostname
-    __all__.append("match_hostname")
+        HAVE_CONTEXT_CHECK_HOSTNAME = False
+        if hasattr(ssl, "match_hostname"):
+            from ssl import match_hostname
+        else:
+            from backports.ssl_match_hostname import match_hostname
+        __all__.append("match_hostname")
+    __all__.append("HAVE_CONTEXT_CHECK_HOSTNAME")
 
     HAVE_SSL = True
 except ImportError:


### PR DESCRIPTION
I see you've been working on this as well. I believe that my fix, while a bit more clumsy, is still relevant, though:

* Works on PY3 < 3.4.
* Prevents setting `check_hostname` to True when `cert_reqs == ssl.CERT_NONE`.
* Prevents double-checking hostname when builtin is available.

I've tested this on echo and our service (with SNI required) with py 2.7.3, 2.7.9, 3.2.5 and 3.4.3.

Fill free to do whatever, though :-).