### PR TITLE
Make websockets iterable

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -154,6 +154,19 @@ class WebSocket(object):
         else:
             self.lock = NoLock()
 
+    def __iter__(self):
+        """
+        Allow iteration over websocket, implying sequential `recv` executions.
+        """
+        while True:
+            yield self.recv()
+
+    def __next__(self):
+        return self.recv()
+
+    def next(self):
+        return self.__next__()
+
     def fileno(self):
         return self.sock.fileno()
 

--- a/websocket/tests/test_websocket.py
+++ b/websocket/tests/test_websocket.py
@@ -255,6 +255,19 @@ class WebSocketTest(unittest.TestCase):
         data = sock.recv()
         self.assertEqual(data, "Hello")
 
+    @unittest.skipUnless(TEST_WITH_INTERNET, "Internet-requiring tests are disabled")
+    def testIter(self):
+        count = 2
+        for rsvp in ws.create_connection('ws://stream.meetup.com/2/rsvps'):
+            count -= 1
+            if count == 0:
+                break
+
+    @unittest.skipUnless(TEST_WITH_INTERNET, "Internet-requiring tests are disabled")
+    def testNext(self):
+        sock = ws.create_connection('ws://stream.meetup.com/2/rsvps')
+        self.assertEqual(str, type(next(sock)))
+
     def testInternalRecvStrict(self):
         sock = ws.WebSocket()
         s = sock.sock = SockMock()


### PR DESCRIPTION
Add `__iter__`, `__next__`, and `next` methods to WebSocket, allowing them to be iterated over, allowing for pythonic sequential calls to `recv`.  This means you can slice, map, filter, etc, websockets without having to roll your own generator each time.  This means you can write code like:

```python
for rsvp in ws.create_connection('ws://stream.meetup.com/2/rsvps'):
    print(rsvp)
```

Or for filtering/mapping:

```python
sock = ws.create_connection('ws://stream.meetup.com/2/rsvps')
for attending in filter(lambda rsvp: rsvp['response'] == 'yes', map(json.loads, sock)):
    print(attending)
```
