### PR TITLE
add support for ssl cert chains to support client certs

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -132,6 +132,9 @@ def _wrap_sni_socket(sock, sslopt, hostname, check_hostname):
         context.check_hostname = check_hostname
     if 'ciphers' in sslopt:
         context.set_ciphers(sslopt['ciphers'])
+    if 'cert_chain' in sslopt :
+        certfile,keyfile,password = sslopt['cert_chain']
+        context.load_cert_chain(certfile,keyfile,password)
 
     return context.wrap_socket(
         sock,


### PR DESCRIPTION
This small patch allows callers to specify a certificate chain in support of client ssl certificates using the existing sslopt parameter.  It can be used as:

   ws = websocket.WebSocket(sslopt={'cert_chain': ("clientCert.pem", "clientKey.pem", lambda *args: "pw"})
   ws.connect(url)
   ws.send() / ws.recv()...

the "cert_chain" tuple provides arguments to the SSLContext.load_cert_chain(certfile, keyfile=None, password=None) API call, which provides a certificate file, a keyfile (can be None to take the key from the same file) and a password callback (can be None to use the builtin password prompting function).