### PR TITLE
Fix string formatting in exception

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -183,7 +183,7 @@ def _tunnel(sock, host, port, auth):
 
     if status != 200:
         raise WebSocketProxyException(
-            "failed CONNECT via proxy status: %r" + status)
+            "failed CONNECT via proxy status: %r" % status)
     
     return sock
 


### PR DESCRIPTION
The intention for this line is clearly to use string formatting, but the string and the variable are just concatenated instead. And because status is an int, the plus sign results in this error being raised:
```
TypeError("cannot concatenate 'str' and 'int' objects",)
```