### PR TITLE
rst invalid rendering on pypi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ WebSocket sample::
 
 
 How to enable `SNI <http://en.wikipedia.org/wiki/Server_Name_Indication>`_?
-------------------
+---------------------------------------------------------------------------
 
 SNI support is available for Python 2.7.9+ and 3.2+. It will be enabled automatically whenever possible.
 


### PR DESCRIPTION
Hi

fix invalid reST doc in README.rst
```
System Message: WARNING/2 (<string>, line 162)

Title underline too short.
```
websocket-client is good module, very useful.

Thanks