### PR TITLE
Map dict to headers list

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -92,8 +92,11 @@ def _get_handshake_headers(resource, host, port, options):
         headers.append("Sec-WebSocket-Protocol: %s" % ",".join(subprotocols))
 
     if "header" in options:
-        headers.extend(options["header"])
-
+        header = options["header"]
+        if isinstance(header, dict):
+            header = map(": ".join, header.items())
+        headers.extend(header)
+        
     cookie = options.get("cookie", None)
 
     if cookie:


### PR DESCRIPTION
Dicts useful for creating many connections with different header values (I use this library in tests).
Please, add this feature.

```python
from websocket import create_connection
create_connection("ws://localhost:12345/services/auth/", header={"my-header": "header_body"})
```
