### PR TITLE
Fix issue #207, Client certificates do not work with 2.7.9+ and 3.2+

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -126,6 +126,12 @@ def _wrap_sni_socket(sock, sslopt, hostname, check_hostname):
     context = ssl.SSLContext(sslopt.get('ssl_version', ssl.PROTOCOL_SSLv23))
 
     context.load_verify_locations(cafile=sslopt.get('ca_certs', None))
+    if sslopt.get('certfile', None):
+        context.load_cert_chain(
+            sslopt['certfile'],
+            sslopt.get('keyfile', None),
+            sslopt.get('password', None),
+        )
     # see https://github.com/liris/websocket-client/commit/b96a2e8fa765753e82eea531adb19716b52ca3ca#commitcomment-10803153
     context.verify_mode = sslopt['cert_reqs']
     if HAVE_CONTEXT_CHECK_HOSTNAME:


### PR DESCRIPTION
(https://github.com/liris/websocket-client/issues/207)
By observing the certfile argument, we can load the cert chain using
the certfile, keyfile and password sslopt values.
A more complete fix might allow us to pass in the SSLContext (rather
than creating it on each connection), which would allow the caller
to set all SSL options prior to calling create_connection() - this
option was passed over as it required more extensive changes.