### PR TITLE
Prints timings in console

### DIFF
--- a/bin/wsdump.py
+++ b/bin/wsdump.py
@@ -58,6 +58,8 @@ def parse_args():
                         help="wait time(second) after 'EOF' recieved.")
     parser.add_argument("-t", "--text",
                         help="Send initial text")
+    parser.add_argument("--timings", action="store_true",
+                        help="Print timings in seconds")
 
     return parser.parse_args()
 
@@ -96,6 +98,7 @@ class NonInteractive(RawInput):
         return self.raw_input("")
 
 def main():
+    start_time = time.time()
     args = parse_args()
     if args.verbose > 1:
         websocket.enableTrace(True)
@@ -149,7 +152,10 @@ def main():
                 msg = "%s: %s" % (websocket.ABNF.OPCODE_MAP.get(opcode), data)
 
             if msg is not None:
-                console.write(msg)
+                if (args.timings):
+                    console.write(str(time.time() - start_time) + ": " + msg)
+                else:
+                    console.write(msg)
 
             if opcode == websocket.ABNF.OPCODE_CLOSE:
                 break


### PR DESCRIPTION
Added functionality in wsdump.py to print timings in console in seconds - handy for measuring performance.

The timer starts in main() - so timings will be printed based on when main() is run.