### PR TITLE
use inspect.getfullargspec with Python 3.x

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -227,8 +227,12 @@ class WebSocketApp(object):
         if they exists, and if the self.on_close except three arguments """
         import inspect
         # if the on_close callback is "old", just return empty list
-        if not self.on_close or len(inspect.getargspec(self.on_close).args) != 3:
-            return []
+        if sys.version_info < (3, 0):
+            if not self.on_close or len(inspect.getargspec(self.on_close).args) != 3:
+                return []
+        else:
+            if not self.on_close or len(inspect.getfullargspec(self.on_close).args) != 3:
+                return []
 
         if data and len(data) >= 2:
             code = 256*six.byte2int(data[0:1]) + six.byte2int(data[1:2])


### PR DESCRIPTION
[inspect.getargspec](https://docs.python.org/3/library/inspect.html#inspect.getargspec) is deprecated as of Python 3.0, and this causes error as below.
```
  File “~/.pyenv/versions/websocket-client/lib/python3.3/site-packages/websocket/_app.py", line 218, in _get_close_args
    if not self.on_close or len(inspect.getargspec(self.on_close).args) != 3:
  File “~/.pyenv/versions/3.3.5/lib/python3.3/inspect.py", line 826, in getargspec
    raise ValueError("Function has keyword-only arguments or annotations”
ValueError: Function has keyword-only arguments or annotations, use getfullargspec() API which can support them
```
I applied a minimal workaround to switch ```inspect.getargspec``` and ```inspect.getfullargspec``` depending on Python version.