### PR TITLE
Check that exception message is actually a string before trying for substring check

### DIFF
--- a/websocket/_socket.py
+++ b/websocket/_socket.py
@@ -115,7 +115,7 @@ def send(sock, data):
         raise WebSocketTimeoutException(message)
     except Exception as e:
         message = extract_err_message(e)
-        if message and "timed out" in message:
+        if isinstance(message, str) and "timed out" in message:
             raise WebSocketTimeoutException(message)
         else:
             raise


### PR DESCRIPTION
One possibility would also to check for stringness already in the extract_err_message, but I didn't do that here.