### PR TITLE
Use pre-initialized stream socket

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -90,6 +90,7 @@ def create_connection(url, timeout=None, **options):
              "subprotocols" - array of available sub protocols.
                               default is None.
              "skip_utf8_validation" - skip utf8 validation.
+             "socket" - pre-initialized stream socket.
     """
     sockopt = options.get("sockopt", [])
     sslopt = options.get("sslopt", {})
@@ -261,9 +262,11 @@ class WebSocket(object):
                                      defualt is None
                  "subprotocols" - array of available sub protocols.
                                   default is None.
+                 "socket" - pre-initialized stream socket.
 
         """
-        self.sock, addrs = connect(url, self.sock_opt, proxy_info(**options))
+        self.sock, addrs = connect(url, self.sock_opt, proxy_info(**options),
+                                   options.pop('socket', None))
 
         try:
             self.handshake_response = handshake(self.sock, *addrs, **options)

--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -51,8 +51,12 @@ class proxy_info(object):
             self.auth = None
             self.no_proxy = None
 
-def connect(url, options, proxy):
+def connect(url, options, proxy, socket):
     hostname, port, resource, is_secure = parse_url(url)
+
+    if socket:
+        return socket, (hostname, port, resource)
+
     addrinfo_list, need_tunnel, auth = _get_addrinfo_list(hostname, port, is_secure, proxy)
     if not addrinfo_list:
         raise WebSocketException(


### PR DESCRIPTION
Allow creating WebSocket connection on existing stream socket instance (either TCP or SSL).
This is useful, for example, when custom validation of server certificate is needed.