### PR TITLE
Exclude port 443 from host http header

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -77,7 +77,7 @@ def _get_handshake_headers(resource, host, port, options):
     headers.append("GET %s HTTP/1.1" % resource)
     headers.append("Upgrade: websocket")
     headers.append("Connection: Upgrade")
-    if port == 80:
+    if port == 80 or port == 443:
         hostport = host
     else:
         hostport = "%s:%d" % (host, port)


### PR DESCRIPTION
It looks to be common standard to strip the default http-based ports from the host header, when the port in mention is one of the two common default ports (e.g. port 80 and 443). This relates specifically to the initial negotiation.

E.g. for example: https://github.com/request/request/issues/515#issuecomment-16449162

I have been running into issues with this library directly, due to it commonly breaking upon handshakes with strictly-https endpoints.