### PR TITLE
_send_ping graceful error handling

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -130,7 +130,11 @@ class WebSocketApp(object):
         while not event.wait(interval):
             self.last_ping_tm = time.time()
             if self.sock:
-                self.sock.ping()
+                try:
+                    self.sock.ping()
+                except Exception as ex:
+                    warning("send_ping routine terminated: {}".format(ex))
+                    break
 
     def run_forever(self, sockopt=None, sslopt=None,
                     ping_interval=0, ping_timeout=None,

--- a/websocket/_logging.py
+++ b/websocket/_logging.py
@@ -53,6 +53,10 @@ def error(msg):
     _logger.error(msg)
 
 
+def warning(msg):
+    _logger.warning(msg)
+
+
 def debug(msg):
     _logger.debug(msg)
 


### PR DESCRIPTION
- logging warning to websocket logger when self.sock.ping() fails
- graceful thread termination, instead leaving an uncaught exception, useful when using sys.execpthook. The error will still be reported from run_forever() routine in a better fashion. 