### PR TITLE
setup.py: Import `logging` before calling it.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ try:
             if key.startswith(':') and pkg_resources.evaluate_marker(key[1:]):
                 install_requires.extend(value)
 except Exception:
+    import logging
     logging.getLogger(__name__).exception(
         'Something went wrong calculating platform specific dependencies, so '
         "you're getting them all!"


### PR DESCRIPTION
Commit 4dcd960427716289fb3446600a13634215f8d3c6 introduces an exception
handling branch that uses the `logging` module to report an exception to
the user, but fails to import the `logging` module first.

This generated the following error in our CI environment:

03-Oct-2016 17:20:51    + python setup.py --command-package stdeb.command sdist_dsc --package python-websocket --source websocket
03-Oct-2016 17:20:51    Traceback (most recent call last):
03-Oct-2016 17:20:51      File "setup.py", line 29, in <module>
03-Oct-2016 17:20:51        logging.getLogger(**name**).exception(
03-Oct-2016 17:20:51    NameError: name 'logging' is not defined

This puts an `import` statement at the location where the `logging`
module is called.
