### PR TITLE
Support CA bundle specified by environment variable

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -165,8 +165,11 @@ def _ssl_socket(sock, user_sslopt, hostname):
     sslopt = dict(cert_reqs=ssl.CERT_REQUIRED)
     sslopt.update(user_sslopt)
 
-    certPath = os.path.join(
-        os.path.dirname(__file__), "cacert.pem")
+    if os.environ.get('WEBSOCKET_CLIENT_CA_BUNDLE'):
+        certPath = os.environ.get('WEBSOCKET_CLIENT_CA_BUNDLE')
+    else:
+        certPath = os.path.join(
+            os.path.dirname(__file__), "cacert.pem")
     if os.path.isfile(certPath) and user_sslopt.get('ca_certs', None) is None:
         sslopt['ca_certs'] = certPath
     check_hostname = sslopt["cert_reqs"] != ssl.CERT_NONE and sslopt.pop(


### PR DESCRIPTION
There's currently no way to define a custom list of trusted CAs and
certain uses-cases end up in SSLError. This commit adds a check for the
WEBSOCKET_CLIENT_CA_BUNDLE env variable, similarly to requests library
which accepts REQUETS_CA_BUNDLE.